### PR TITLE
Replace the isLikelyLatex() function with this more conservative version

### DIFF
--- a/typingmindlatexfix.js
+++ b/typingmindlatexfix.js
@@ -39,19 +39,21 @@
     }
 
     function isLikelyLatex(content) {
-        if (/^\s*\d+\s*$/.test(content)) {
-            return false;
-        }
-
-        return (
-            /[_^{}\\]/.test(content) ||
-            /\\?[a-zA-Z]{2,}/.test(content) ||
-            /[∫∑∏√∞±≤≥≠]/.test(content) ||
-            /[α-ωΑ-Ω]/.test(content) ||
-            /\\left|\\right/.test(content) ||
-            /\\frac|\\int/.test(content)
-        );
+    if (/^\s*\d+\s*$/.test(content)) {
+        return false;
     }
+
+    return (
+        /[_^{}\\]/.test(content) ||                    // LaTeX syntax chars
+        /\\[a-zA-Z]+/.test(content) ||                 // Actual LaTeX commands (\alpha, \frac)
+        /[∫∑∏√∞±≤≥≠≈∝∂∇]/.test(content) ||           // Math symbols
+        /[α-ωΑ-Ω]/.test(content) ||                    // Greek letters
+        /\b(sin|cos|tan|log|ln|exp|lim|int|sum|prod)\b/.test(content) || // Math functions
+        /\^[^a-zA-Z\s]/.test(content) ||               // Superscripts with symbols
+        /_[^a-zA-Z\s]/.test(content)                   // Subscripts with symbols
+    );
+}
+
 
     async function loadTeXZilla() {
         if (state.teXZillaLoaded) return;


### PR DESCRIPTION
## Fix LaTeX detection false positives

**Problem:** The current `isLikelyLatex()` function incorrectly identifies regular English text in parentheses as LaTeX expressions, causing garbled MathML rendering.

**Root cause:** The regex `/\\?[a-zA-Z]{2,}/` matches any multi-letter word, not just LaTeX commands.

**Solution:** 
- Replace broad pattern with more specific LaTeX syntax detection
- Require actual LaTeX commands (`\alpha`), math symbols, or explicit syntax
- Preserve legitimate math rendering while eliminating false positives